### PR TITLE
add CLI-driven, optional build context

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# shellcheck disable=SC2148
+use flake .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .aws-lambda-rie
+.direnv
 dist
 main
 mockRepo
 justfile
+result

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Self
 
-Self provides developers the means to confidently publish and deploy their code to AWS Lambda.
+Self provides developers the means to confidently publish and deploy their code
+to AWS Lambda.

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -34,6 +34,8 @@ type ReleaseOpts struct {
 	EnsureRepository bool `arg:"-r,--ensure-repository,env:ENSURE_REPOSITORY"`
 	// Default: false
 	Login bool `arg:"-l,--ecr-login" help:"Login to ECR"`
+	// Default: the current function path.
+	Context string `arg:"-c,--context" help:"Function build context"`
 	// Default: false
 	SSHAgent bool `arg:"-a,--ssh-agent" help:"mount ssh-agent into build (TODO)"`
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719506693,
+        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ] (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        version = builtins.substring 0 8 self.lastModifiedDate;
+      in
+      rec {
+        packages = rec {
+          default = pkgs.buildGo122Module rec {
+            pname = "self";
+            inherit version;
+            src = ./.;
+            subPackages = [ "cmd/self" ];
+            vendorHash = "sha256-E0TSkI5jVQsmU8FBwnWQfn0wsmM87mPjwuSBa4Do6BE=";
+          };
+        };
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+            go-tools
+            gotools
+            gopls
+          ];
+
+          AWS_REGION = "us-west-2";
+          AWS_PROFILE = "linecard";
+        };
+      });
+}

--- a/pkg/convention/release/release.go
+++ b/pkg/convention/release/release.go
@@ -28,7 +28,7 @@ type RegistryService interface {
 
 type BuildService interface {
 	InspectByTag(ctx context.Context, registryUrl, repository, tag string) (types.ImageInspect, error)
-	Build(ctx context.Context, path string, labels map[string]string, tags []string) error
+	Build(ctx context.Context, functionPath, contextPath string, labels map[string]string, tags []string) error
 	Push(ctx context.Context, tag string) error
 }
 
@@ -170,7 +170,7 @@ func (c Convention) Publish(ctx context.Context, i Image) error {
 	return nil
 }
 
-func (c Convention) Build(ctx context.Context, functionPath, branch, sha string) (Image, error) {
+func (c Convention) Build(ctx context.Context, functionPath, contextPath, branch, sha string) (Image, error) {
 	registryUrl := c.Config.Registry.Url
 	repository := c.Config.Repository.Prefix + "/" + c.Config.Function.Name
 
@@ -185,7 +185,7 @@ func (c Convention) Build(ctx context.Context, functionPath, branch, sha string)
 		fmt.Sprintf("%s/%s:%s", registryUrl, repository, sha),
 	}
 
-	if err := c.Service.Build.Build(ctx, functionPath, labels, tags); err != nil {
+	if err := c.Service.Build.Build(ctx, functionPath, contextPath, labels, tags); err != nil {
 		return Image{}, err
 	}
 

--- a/pkg/convention/release/release_test.go
+++ b/pkg/convention/release/release_test.go
@@ -77,14 +77,14 @@ func TestRelease(t *testing.T) {
 					"123456789013.dkr.ecr.us-west-2.amazonaws.com/mockOrg/mockRepo/function-one:4eeac06a6b0d37a30bd45775b19e59a06c3b6295",
 				}
 
-				mbs.On("Build", mock.Anything, config.Function.Path, expectedLabels, expectedTags).Return((error)(nil))
+				mbs.On("Build", mock.Anything, config.Function.Path, config.Function.Path, expectedLabels, expectedTags).Return((error)(nil))
 
 				mockImageInspect := mockservice.MockImageInspect(config, nil)
 				mbs.On("InspectByTag", mock.Anything, config.Registry.Url, config.Repository.Prefix+"/"+config.Function.Name, "4eeac06a6b0d37a30bd45775b19e59a06c3b6295").Return(mockImageInspect, (error)(nil))
 			},
 			test: func(t *testing.T, mbs *mockservice.MockBuildService, mrs *mockservice.MockRegistryService) {
 				releases := FromServices(config, mrs, mbs)
-				image, err := releases.Build(ctx, config.Function.Path, config.Git.Branch, config.Git.Sha)
+				image, err := releases.Build(ctx, config.Function.Path, config.Function.Path, config.Git.Branch, config.Git.Sha)
 				assert.IsType(t, Image{}, image)
 				assert.NoError(t, err)
 			},

--- a/pkg/mock/service/build.go
+++ b/pkg/mock/service/build.go
@@ -17,8 +17,8 @@ func (m *MockBuildService) InspectByTag(ctx context.Context, registryUrl, reposi
 	return args.Get(0).(types.ImageInspect), args.Error(1)
 }
 
-func (m *MockBuildService) Build(ctx context.Context, path string, labels map[string]string, tags []string) error {
-	args := m.Called(ctx, path, labels, tags)
+func (m *MockBuildService) Build(ctx context.Context, functionPath, contextPath string, labels map[string]string, tags []string) error {
+	args := m.Called(ctx, functionPath, contextPath, labels, tags)
 	return args.Error(0)
 }
 

--- a/pkg/service/docker/docker.go
+++ b/pkg/service/docker/docker.go
@@ -78,14 +78,14 @@ func (s Service) InspectByTag(ctx context.Context, registryUrl, repository, tag 
 	return inspectData[0], nil
 }
 
-func (s Service) Build(ctx context.Context, path string, labels map[string]string, tags []string) error {
+func (s Service) Build(ctx context.Context, functionPath, contextPath string, labels map[string]string, tags []string) error {
 	envs := []string{
 		"DOCKER_BUILDKIT=1",
 	}
 
 	args := []string{
 		"build",
-		"-f", path + "/Dockerfile",
+		"-f", functionPath + "/Dockerfile",
 	}
 
 	for _, tag := range tags {
@@ -96,7 +96,7 @@ func (s Service) Build(ctx context.Context, path string, labels map[string]strin
 		args = append(args, "--label", fmt.Sprintf("%s=%s", key, value))
 	}
 
-	args = append(args, path)
+	args = append(args, contextPath)
 
 	cmd := exec.CommandContext(ctx, s.Binary, args...)
 	cmd.Env = append(os.Environ(), envs...)


### PR DESCRIPTION
Adds:
- `--context, -c` flag for both `run` and `publish`
- `flake.nix` for build environment and packaging

Enables:
- Adjusting Docker's build context for projects with nested `cmd/<app>` entry points

Examples:
- `self run --context ../../../../`
- `self run --context /Users/raymond/src/edge/`

Notes:
- Defaults to `Config.Function.Path`

